### PR TITLE
v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.4 - 2023-02-15
+
+- Raise minimum Laravel version to 10
+
 ## 0.3.1 - 2022-02-20
 
 - Update for Laravel 9 compatibility

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,15 @@
 		}
 	},
 	"require": {
-		"php": ">7.3",
+		"php": ">=8.1",
 		"predis/predis": "^1.1",
 		"nesbot/carbon": "^2.31",
-		"illuminate/redis": "^8.0|^9.0",
-		"illuminate/support": "^8.0|^9.0"
+		"illuminate/redis": "^10.0",
+		"illuminate/support": "^10"
 	},
 	"require-dev": {
 		"orchestra/testbench": "^6.0",
-		"phpunit/phpunit": "^8.0|^9.0",
-		"mockery/mockery": "^1.0"
+		"phpunit/phpunit": "^10.0",
+		"mockery/mockery": "^1.4.4"
 	}
 }


### PR DESCRIPTION
Raise minimum PHP and Illuminate package versions for Laravel 10 compatibility. Drop anything below L10.