### PR TITLE
Laravel 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,34 @@
 # CHANGELOG
 
+## 0.5 - 2024-12-07
+
+-   Raise minimum Laravel version to 11
+-   Raise minimum PHP version to 8.3
+-   Fix `block_timeout` not being used
+-   Fix filter not working correctly with sequential array
+
 ## 0.4 - 2023-02-15
 
-- Raise minimum Laravel version to 10
+-   Raise minimum Laravel version to 10
 
 ## 0.3.1 - 2022-02-20
 
-- Update for Laravel 9 compatibility
+-   Update for Laravel 9 compatibility
 
 ## 0.3 - 2021-05-08
 
-- [ch445] Add option for IP hashing
-- [ch441] Add filter option for user Agents
-- [ch441] Change `$type` parameter in callbacks to `$criteriaBits`
-- Change namespace from `Dsone\ExceptionHandler` to `Dsone\Strainex`
+-   [ch445] Add option for IP hashing
+-   [ch441] Add filter option for user Agents
+-   [ch441] Change `$type` parameter in callbacks to `$criteriaBits`
+-   Change namespace from `Dsone\ExceptionHandler` to `Dsone\Strainex`
 
 ## 0.2 - 2021-03-06
 
-- Supporting map table instead of sequential array for SEO spam referer list
-- Support for `exit` instead of returning response codes
-- Adding PHP 7.3 as dependency
-- Formatting/expanding README
+-   Supporting map table instead of sequential array for SEO spam referer list
+-   Support for `exit` instead of returning response codes
+-   Adding PHP 7.3 as dependency
+-   Formatting/expanding README
 
 ## 0.1 - 2021-03-06
 
-- Initial version
+-   Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -   Raise minimum PHP version to 8.3
 -   Fix `block_timeout` not being used
 -   Fix filter not working correctly with sequential array
+-   Allow callbacks to be callables, or static/instance methods on classes
 
 ## 0.4 - 2023-02-15
 

--- a/README.md
+++ b/README.md
@@ -5,53 +5,59 @@ There's an absurd amount of noise for the yet bazillionth time scan of a technol
 Strainex might be of service to you.
 
 ### Beware
+
 _Strainex is not meant to make your website more secure._
 
 If you want to make your website more secure than this is not the package you're looking for.  
 In such cases a honeypot setup, fail2ban, plain DENY/ALLOW in your .htaccess or similar tools might be better suited for your use case.
 
 ## What Strainex does: reducing noise
+
 Strainex is an attempt at reducing noise in your (custom) logging for when errors occur. By filtering out common SEO spam and scan attempts that end in a 404 most of the times in an easy way.  
 It's customizable, so you can add arbitrary URL requests to "block" further requests from that one entity visiting you on a daily basis.  
 Blocking here means two things:
+
 1. Preventing any more exception handlers to run, which in turn would trigger your custom logging/handling (basically "filtering")
 2. Optionally prevent any further requests from the same IP for a configurable time (proper "blocking")
-  
+
 With Strainex you can keep those logs of yours a bit more clean by reducing the noise easily by 90% that way.
 
 ### How it works
+
 When an entity requests a URL from your Laravel website, like `example.com/wp-admin`, it usually returns a 404 in a Laravel context. Within Laravel, a 404 is an HttpException. It is thrown somewhere in your application for a not found route.
-  
+
 The default Exception handler in `app\Exceptions\Handler` is invoked at last (unless re-configured with other handlers), doing whatever you have configured in there for such cases. The entity gets to see the 404 only (or any other triggered exception code) and goes ahead to request the next URL like `example.com/vendor/phpunit`, rinse and repeat. Filling up your logs with noise.
-  
+
 Strainex does not change the normal behaviour of how Laravel handles these exceptions. Instead, it adds onto that by wrapping itself around these exceptions (404 and other HttpExceptions) via a Decorator Pattern, checks if certain configured routes were accessed, specific referer or user agents are detected and aborts itself before invoking any other exception handlers.
-  
+
 If blocking is enabled, Strainex saves the IP in a Redis instance. The next request from that IP is checked within the boot process of Laravel. If the request is from a known entity, Strainex aborts the boot process. Strainex returns a configurable response code (default 500 for blocked, 503 for filtered) or simply exits. Keeping your logs clean(er) and your app from bootstrapping any further.
 
 ## Requirements
-* PHP >=7.3
-* Laravel >8.*
-* Redis _(optional)_
-  
-If you want to also block entities, you need Redis setup on your machine. 
+
+-   PHP >=8.3
+-   Laravel >=11.\*
+-   Redis _(optional)_
+
+If you want to also block entities, you need Redis setup on your machine.
 In that case any subsequent request of a previously blocked entity is being prevented by aborting early.
 
 ## Installation
 
 1. Add this repository to your composer json:
-	```
-	"repositories": [
-		{ "type": "vcs", "url": "https://github.com/dsone/strainex" }
-	]
-	```
-2. Install via 
-	`composer require dsone/strainex`
+    ```
+    "repositories": [
+    	{ "type": "vcs", "url": "https://github.com/dsone/strainex" }
+    ]
+    ```
+2. Install via
+   `composer require dsone/strainex`
 3. Publish config of `Dsone\Strainex\Providers\StrainexServiceProvider` via
-	`php artisan vendor:publish` 
+   `php artisan vendor:publish`
 4. Read commentary in `config/strainex.php` and edit settings for the URL and referer to filter out
 5. Edit .env vars as you see fit or leave defaults as defined in the config file
 
 ## Credit
+
 ...where credit is due.
-  
+
 The Decorator Pattern around exception handling in Laravel was adapted from [cerbero90/exception-handler](https://github.com/cerbero90/exception-handler).

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,15 @@
 		}
 	},
 	"require": {
-		"php": ">=8.1",
-		"predis/predis": "^1.1",
-		"nesbot/carbon": "^2.31",
-		"illuminate/redis": "^10.0",
-		"illuminate/support": "^10"
+		"php": "^8.3",
+		"predis/predis": ">=1.1",
+		"nesbot/carbon": ">=2.31",
+		"illuminate/redis": ">=10.0",
+		"illuminate/support": ">=10"
 	},
 	"require-dev": {
-		"orchestra/testbench": "^6.0",
-		"phpunit/phpunit": "^10.0",
-		"mockery/mockery": "^1.4.4"
+		"orchestra/testbench": ">=6.0",
+		"phpunit/phpunit": "^11.3.6",
+		"mockery/mockery": "^1.6"
 	}
 }

--- a/src/Classes/StrainexDecorator.php
+++ b/src/Classes/StrainexDecorator.php
@@ -75,7 +75,7 @@ class StrainexDecorator implements ExceptionHandler
 	 * @return	boolean				True on match, false otherwise.
 	 */
 	private function isMatch(string $needle, Array $haystack) {
-		if (isset($mapping[0])) {  // sequential array
+		if (isset($haystack[0])) {  // sequential array
 			return in_array($needle, $haystack);
 		}
 
@@ -138,7 +138,7 @@ class StrainexDecorator implements ExceptionHandler
 						config('strainex.redis_string', 'strainex:ip:ban:') . $ip,
 						serialize($data),
 						'ex',  // define 4th param as seconds
-						(config('app.env', 'production') === 'local' ? 15 : 21600)  // 15s in dev, 6h in non-dev
+						(config('app.env', 'production') === 'local' ? 10 : config('strainex.block_timeout'))  // 10s in dev, 6h in prod
 					);
 
 					// Invoke optional callback

--- a/src/config/strainex.php
+++ b/src/config/strainex.php
@@ -33,14 +33,14 @@ return [
 		 * Map: [ 'A' => 1, 'B' => 1, 'C' => 1, 'D' => 1, 'E' => 1 ] - a lot better for large lists
 		 */
 		'referer' => [
-			
+
 		],
 		/**
 		 * Similar to the referers but for the User-Agent strings.
 		 * userAgents are checked in lowercase, hence use lowercase here.
 		 */
 		'userAgents' => [
-			
+
 		],
 		/**
 		 * RegExp usable partial URL strings.
@@ -90,16 +90,24 @@ return [
 	/**
 	 * Optional callables that are invoked at different states.
 	 * 
-	 * Can be a class with a _static_ `method` in the form of
+	 * Can be a class with a method in the form of
 	 *   [ MyExceptionEvent:class, 'method' ].
+	 * `method` can be static or non-static.
+	 * Examples:
+	 * ```php
+	 * 'blocked' => [ [ App\Utils\StrainexCallbacks::class, 'blocked' ] ]
+	 * 'blocked' => function() { dd('blocked'); }
+	 * 'blocked' => [ function() { dd('blocked') }, [ App\Utils\StrainexCallbacks::class, 'blocked' ] ]
+	 * ```
 	 * 
-	 * Beware that when a second request for an IP blocked entity comes along,
+	 * Beware that when a second request for an IP-blocked-entity comes along,
 	 * the invoked callback might not be able to use all of Laravel's features,
 	 * since Strainex tries to leave the boostrapping asap. 
 	 */
 	'callbacks' => [
 		/**
-		 * A request was blocked, only invokable if block_requests is true.
+		 * A request was blocked, only invokable if `block_requests` is true.
+		 * 
 		 * The checks to block are in this order: SEO (bit 1), userAgent (bit 2), URL (bit 4).
 		 * $criteriaBits will be a bitmask of what matched the criteria to block the entity.
 		 * An entity provoking a 404 with a userAgent match will therefore have the bit (2 | 4) = 6.
@@ -111,13 +119,17 @@ return [
 		 */
 		'blocked'	=> false,
 		/**
-		 * Almost the same as blocked, just that this is only invokable if block_requests is false.
+		 * The replacement callback for when `block_requests` is false.
+		 * If you do not want to block requests directly and automatically, you can use this callback.
+		 * 
 		 * The callable gets only the original $exception and $criteriaBits as parameter.
 		 */
 		'filtered'	=> false,
 		/**
-		 * The negated case of filtered and blocked basically.
-		 * Most useful for debugging purposes.
+		 * Valid requests that are not blocked/filtered but raise an exception anyway.
+		 * 
+		 * Most useful for debugging purposes only or to count errors raised by specific IPs.
+		 * 
 		 * Does not rely on the block_requests setting.
 		 */
 		'passed'	=> false


### PR DESCRIPTION
-   Raise minimum Laravel version to 11
-   Raise minimum PHP version to 8.3
-   Fix `block_timeout` not being used
-   Fix filter not working correctly with sequential array
-   Allow callbacks to be callables, or static/instance methods on classes